### PR TITLE
Fixes for class and var declarations

### DIFF
--- a/syntaxes/bl4.tmLanguage.json
+++ b/syntaxes/bl4.tmLanguage.json
@@ -77,7 +77,7 @@
     "class-dec": {
       "name": "meta.entity.class.bl4",
       "begin": "(class)\\s+(\\w+)",
-      "end": "(?=})",
+      "end": "\\s*(?=decl|class)",
       "captures": {
         "1": {
           "name": "storage.type.class.bl4"
@@ -96,7 +96,7 @@
           }
         },
         {
-          "include": "#type"
+          "include": "#field-dec"
         },
         {
           "include": "#comments"
@@ -212,18 +212,41 @@
     },
     "global-dec": {
       "name": "meta.entity.global.bl4",
-      "begin": "(decl)",
+      "begin": "(decl)\\s+(\\w+)\\s*(:)",
       "end": "$\\n?",
       "beginCaptures": {
-        "0": {
+        "1": {
           "name": "keyword.other.global.bl4"
+        },
+        "2": {
+          "name": "variable.name.global.bl4"
+        },
+        "3": {
+          "name": "keyword.other.colon.bl4"
         }
       },
       "patterns": [
-        {
-          "name": "support.function",
-          "match": "\\s+(\\w+)(.\\w+)?(\\s+[+-]\\s+)?(\\d+)?"
+            {
+              "include": "#type"
+            }
+      ]
+    },
+    "field-dec": {
+      "name": "meta.entity.field.bl4",
+      "begin": "(\\w+)\\s*(:)",
+      "end": "$\\n?",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.name.global.bl4"
+        },
+        "2": {
+          "name": "keyword.other.colon.bl4"
         }
+      },
+      "patterns": [
+            {
+              "include": "#type"
+            }
       ]
     }
   },


### PR DESCRIPTION
The end of the class section was defined by `}`
But it's possible for a class to have no body at all, so end of the class is defined by the start of the next section (class or decl).
global declaration enhanced to separate name of declared variable.